### PR TITLE
Introduce SM_SERIAL_PORT_NULL

### DIFF
--- a/include/SMuFF.h
+++ b/include/SMuFF.h
@@ -24,11 +24,21 @@
 #include "Strings.h"
 #include "GCodes.h"
 
-#if !defined(USE_SERIAL_DISPLAY)
+#define SM_SERIAL_PORT_NULL -1
+#ifdef USE_SERIAL_DISPLAY
+  #define SM_SHOULD_SHOW_MESSAGE(__serial__) \
+    __serial__ != SM_SERIAL_PORT_NULL \
+    && smuffConfig.displaySerial != SM_SERIAL_PORT_NULL \
+    && __serial__ == smuffConfig.displaySerial
+#else
+  #define SM_SHOULD_SHOW_MESSAGE(__serial__) false
+#endif
+
+#ifndef USE_SERIAL_DISPLAY
 #include <U8g2lib.h>
 #include "Menus.h"
 #include "InputDialogs.h"
-#define DISPLAY_SERIAL_PORT -1
+#define DISPLAY_SERIAL_PORT SM_SERIAL_PORT_NULL
 #endif
 
 #if defined(USE_LEONERD_DISPLAY)

--- a/src/DisplayTools.cpp
+++ b/src/DisplayTools.cpp
@@ -400,7 +400,7 @@ void drawPurgingMessage(uint16_t len, uint8_t tool) {
   if (displayingUserMessage) // don't show if something else is being displayed
     return;
   if(len == 0 && tool == 0) {
-    if(currentSerial != -1) {
+    if(currentSerial != SM_SERIAL_PORT_NULL) {
       sprintf_P(tmp, PSTR("echo: purging: done\n"));
       printResponse(tmp, currentSerial);
     }
@@ -420,7 +420,7 @@ void drawPurgingMessage(uint16_t len, uint8_t tool) {
   display.updateDisplay();
   if(smuffConfig.webInterface) {
     sprintf_P(tmp, PSTR("echo: purging: T:%d L:%d C:%f\n"), tool, len, len*2.4);
-    if(currentSerial != -1)
+    if(currentSerial != SM_SERIAL_PORT_NULL)
       printResponse(tmp, currentSerial);
   }
 #if defined(USE_TERMINAL_MENUS)
@@ -701,8 +701,9 @@ uint8_t showDialog(PGM_P title, PGM_P message, PGM_P addMessage, PGM_P buttons, 
   char dlg[1024];
 
   // no action if no display serial port is defined
-  if(smuffConfig.displaySerial == -1)
+  if(smuffConfig.displaySerial == SM_SERIAL_PORT_NULL) {
     return state;
+  }
 
   setFastLEDStatus(FASTLED_STAT_WARNING);
   String btn(buttons);

--- a/src/GCodes.cpp
+++ b/src/GCodes.cpp
@@ -2321,7 +2321,7 @@ bool M577(const char *msg, String buf, int8_t serial, char* errmsg) {
 bool M700(const char *msg, String buf, int8_t serial, char* errmsg)
 {
   bool stat = false;
-  bool showMsg = serial==smuffConfig.displaySerial ? true : false;
+  bool showMsg = SM_SHOULD_SHOW_MESSAGE(serial);
 
   printResponse(msg, serial);
   currentSerial = serial;
@@ -2356,7 +2356,7 @@ bool M700(const char *msg, String buf, int8_t serial, char* errmsg)
 bool M701(const char *msg, String buf, int8_t serial, char* errmsg)
 {
   bool stat = false;
-  bool showMsg = serial==smuffConfig.displaySerial ? true : false;
+  bool showMsg = SM_SHOULD_SHOW_MESSAGE(serial);
 
   printResponse(msg, serial);
   currentSerial = serial;
@@ -2848,7 +2848,7 @@ bool G12(const char *msg, String buf, int8_t serial, char* errmsg)
 bool G28(const char *msg, String buf, int8_t serial, char* errmsg)
 {
   bool stat = true;
-  bool showMsg = serial==smuffConfig.displaySerial ? true : false;
+  bool showMsg = SM_SHOULD_SHOW_MESSAGE(serial);
 
   printResponse(msg, serial);
   if (buf.length() == 0)

--- a/src/SMuFF.cpp
+++ b/src/SMuFF.cpp
@@ -983,25 +983,25 @@ void loopEx() {
 
 void fncKey1() {
   if (strlen(smuffConfig.lButtonDown) > 0) {
-    parseGcode(String(smuffConfig.lButtonDown), -1);
+    parseGcode(String(smuffConfig.lButtonDown), SM_SERIAL_PORT_NULL);
   }
 }
 
 void fncKey2() {
   if (strlen(smuffConfig.lButtonHold) > 0) {
-    parseGcode(String(smuffConfig.lButtonHold), -1);
+    parseGcode(String(smuffConfig.lButtonHold), SM_SERIAL_PORT_NULL);
   }
 }
 
 void fncKey3() {
   if (strlen(smuffConfig.rButtonDown) > 0) {
-    parseGcode(String(smuffConfig.rButtonDown), -1);
+    parseGcode(String(smuffConfig.rButtonDown), SM_SERIAL_PORT_NULL);
   }
 }
 
 void fncKey4() {
   if (strlen(smuffConfig.rButtonHold) > 0) {
-    parseGcode(String(smuffConfig.rButtonHold), -1);
+    parseGcode(String(smuffConfig.rButtonHold), SM_SERIAL_PORT_NULL);
   }
   else {
     // open / close LID servo by default

--- a/src/SMuFFtools.cpp
+++ b/src/SMuFFtools.cpp
@@ -2187,7 +2187,7 @@ void testRun(const char *fname)
           if (gCode.indexOf("{RNDTL}") > -1) {
             gCode.replace("{RNDTL}", String(tool));
           }
-          parseGcode(gCode, -1);
+          parseGcode(gCode, SM_SERIAL_PORT_NULL);
           //__debugS(D, PSTR("GCode: %s"), gCode.c_str());
           if (*line == 'T')
           {

--- a/src/SimpleGCodeParser.cpp
+++ b/src/SimpleGCodeParser.cpp
@@ -221,7 +221,7 @@ bool parse_T(const String& buf, int8_t serial, char* errmsg) {
           unloadFilament(errmsg);
     }
 
-    bool showMsg = serial==smuffConfig.displaySerial ? true : false;
+    bool showMsg = SM_SHOULD_SHOW_MESSAGE(serial);
     
     if((stat = selectTool(tool, errmsg, showMsg))) {
       if(!smuffConfig.prusaMMU2) {


### PR DESCRIPTION
This change adds two new macro defines: 
- concrete definition of NULL serial port via `SM_SERIAL_PORT_NULL`
- macro checking if the message should be presented with given serial port via `SM_SHOULD_SHOW_MESSAGE`